### PR TITLE
Add some conditional build settings for Linux

### DIFF
--- a/src/fontdiff/fontdiff.gyp
+++ b/src/fontdiff/fontdiff.gyp
@@ -24,6 +24,15 @@
                 '../third_party/freetype/freetype.gyp:freetype',
                 '../third_party/icu/icu.gyp:icu_uc',
             ],
+            'conditions': [
+                ['OS == "linux"', {
+                    # need C++11 flag for unique_ptr
+                    'cflags': ['-std=c++11'],
+                    'link_settings': {
+                        'libraries': ['-ldl'],
+                    },
+                }],
+            ],
         },
         {
             'target_name': 'fontdiff_lib',
@@ -61,6 +70,12 @@
                 '../third_party/icu/icu.gyp:icu_i18n',
                 '../third_party/icu/icu.gyp:icu_uc',
                 '../third_party/icu/icu.gyp:icu_data',
+            ],
+            'conditions': [
+                ['OS == "linux"', {
+                    # need C++11 flag to handle auto keyword
+                    'cflags': ['-std=c++11'],
+                }],
             ],
         },
     ],

--- a/src/third_party/harfbuzz/harfbuzz.gyp
+++ b/src/third_party/harfbuzz/harfbuzz.gyp
@@ -87,6 +87,34 @@
                 '../icu/icu.gyp:icu_uc',
                 '../ragel/ragel.gyp:ragel',
 	    ],
+            'conditions': [
+                ['OS == "linux"', {
+
+                    # This assumes that we're running on Intel.
+                    # The alternative is to run the configuration script, which
+                    # detects architecture. But doing so can cause GLib to be
+                    # chosen over ICU, which causes problems later in linking.
+                    'defines': [
+                        'HAVE_INTEL_ATOMIC_PRIMITIVES',
+                    ],
+
+                    #'actions': [
+                    #    {
+                    #        'action_name': 'gen_config_h',
+                    #        'inputs': ['files/autogen.sh'],
+                    #        'outputs': ['files/config.h'],
+                    #        'action': ['eval', 'cd files && ./autogen.sh'],
+                    #    }
+                    #],
+                    #'defines': [
+                    #    'HAVE_CONFIG_H',
+                    #],
+                    #'include_dirs': [
+                    #    'files',
+                    #],
+
+                }],
+            ],
         },
     ]
 }

--- a/src/third_party/icu/icu.gyp
+++ b/src/third_party/icu/icu.gyp
@@ -530,6 +530,13 @@
                 'icu_stubdata',
 	        'icu_toolutil',
 	    ],
+            'conditions': [
+                ['OS == "linux"', {
+                    'link_settings': {
+                        'libraries': ['-ldl'],
+                    },
+                }],
+            ],
         },
         {
             'target_name': 'genccode',
@@ -543,6 +550,13 @@
                 'icu_stubdata',
 	        'icu_toolutil',
 	    ],
+            'conditions': [
+                ['OS == "linux"', {
+                    'link_settings': {
+                        'libraries': ['-ldl'],
+                    },
+                }],
+            ],
         },
         {
             'target_name': 'genrb',
@@ -568,6 +582,13 @@
                 'icu_stubdata',
 	        'icu_toolutil',
 	    ],
+            'conditions': [
+                ['OS == "linux"', {
+                    'link_settings': {
+                        'libraries': ['-ldl'],
+                    },
+                }],
+            ],
         },
         {
             'target_name': 'pkgdata',

--- a/src/third_party/pixman/pixman.gyp
+++ b/src/third_party/pixman/pixman.gyp
@@ -56,6 +56,11 @@
             'defines': [
                 'HAVE_CONFIG_H',
             ],
+            'conditions': [
+                ['OS == "linux"', {
+                    'cflags': ['-mssse3'],
+                }],
+            ],
         },
     ],
 }


### PR DESCRIPTION
This all feels a bit messy to me, especially how Harfbuzz is handled. But I suppose it's worth it if we can get fontdiff running on travis. Anyways, what's the worst that can happen (honest question)? Hopefully just compilation errors if someone tries to compile with Linux + a non-Intel platform.