### PR TITLE
Fix building Ragel with newer GCC versions

### DIFF
--- a/src/third_party/ragel/ragel.gyp
+++ b/src/third_party/ragel/ragel.gyp
@@ -3,6 +3,11 @@
         {
             'target_name': 'ragel',
             'type': 'executable',
+            'conditions': [
+                ['OS == "linux"', {
+                    'cflags': ['-std=gnu++98'],
+                }],
+            ],
             'sources': [
                 'files/ragel/cdcodegen.cpp',
                 'files/ragel/cdfflat.cpp',


### PR DESCRIPTION
Newer versions of GCC default to C++11, but Ragel build breaks with it.
I’m just checking for Linux here, not sure if there is a better check
for the compiler itself in gyp.